### PR TITLE
add maintainOrder

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -5,7 +5,8 @@
     "dark": "/logo/dark.svg"
   },
   "api": {
-    "baseUrl": ["https://api.axle.insure", "https://sandbox.axle.insure"]
+    "baseUrl": ["https://api.axle.insure", "https://sandbox.axle.insure"],
+    "maintainOrder": true
   },
   "favicon": "/favicon-lg.png",
   "colors": {


### PR DESCRIPTION
Hey! Ronan from Mintlify here

Using `maintainOrder` circumvents some optimizations we make on the backend that have been causing issues recently. We're working to fix these issues and deprecate `maintainOrder` entirely, but this should work for now.